### PR TITLE
fix: incorrect innerOuterMaps subword key does not match it's function

### DIFF
--- a/lua/various-textobjs.lua
+++ b/lua/various-textobjs.lua
@@ -15,7 +15,7 @@ local function setupKeymaps()
 		number = "n",
 		value = "v",
 		key = "k",
-		subWord = "S",
+		subword = "S",
 	}
 	local oneMaps = {
 		nearEoL = "n",


### PR DESCRIPTION
Hi!

I tried to use the subword textobject, and was greeted with this error:

```
E5108: Error executing lua: ...nvim/lazy/nvim-various-textobjs/lua/various-textobjs.lua:53: attempt to call a nil value
stack traceback:
	...nvim/lazy/nvim-various-textobjs/lua/various-textobjs.lua:53: in function <...nvim/lazy/nvim-various-textobjs/lua/various-textobjs.lua:53>
```

I took a look at the source code and realized the `subword` function's name did not matche the `subWord` key in the `innerOuterMaps` map. So this is a small fix for that

Let me know if I missed something, or if something else need to change

Love the project. Thank you for the time and effort! :)