### PR TITLE
Fix gx: Add missing 'vim' to function-call and space between opener and url

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ vim.keymap.set("n", "gx", function ()
 	local url
 	if foundURL then
 		vim.cmd.normal { '"zy', bang = true } -- retrieve URL with "z as intermediary
-		url = fn.getreg("z")
+		url = vim.fn.getreg("z")
 
 		local opener
 		if vim.fn.has("macunix") == 1 then
@@ -140,7 +140,7 @@ vim.keymap.set("n", "gx", function ()
 		elseif vim.fn.has("win64") == 1 or fn.has("win32") == 1 then
 			opener = "start"
 		end
-		os.execute(opener .. "'" .. url .. "'")
+		os.execute(opener .. " '" .. url .. "'")
 	else
 		-- if not found in proximity, search whole buffer via urlview.nvim instead
 		vim.cmd.UrlView("buffer")

--- a/doc/various-textobjs.txt
+++ b/doc/various-textobjs.txt
@@ -219,7 +219,7 @@ buffer for URLs from which you can choose which to open.
         local url
         if foundURL then
             vim.cmd.normal { '"zy', bang = true } -- retrieve URL with "z as intermediary
-            url = fn.getreg("z")
+            url = vim.fn.getreg("z")
     
             local opener
             if vim.fn.has("macunix") == 1 then
@@ -229,7 +229,7 @@ buffer for URLs from which you can choose which to open.
             elseif vim.fn.has("win64") == 1 or fn.has("win32") == 1 then
                 opener = "start"
             end
-            os.execute(opener .. "'" .. url .. "'")
+            os.execute(opener .. " '" .. url .. "'")
         else
             -- if not found in proximity, search whole buffer via urlview.nvim instead
             vim.cmd.UrlView("buffer")


### PR DESCRIPTION
The gx-code-snippet in the README and docs currently doesn't work. `vim` has to be prepended  to `fn.getreg("z")` and a space between the opener and url.