### PR TITLE
Add inner/outer lineCharacterwise textobject and fix keymaps creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Bundle of more than two dozen new text objects for Neovim.
 | restOfParagraph      | like `}`, but linewise                                                                    | \-                                                                                        | no              |           `r`            | all                             |
 | entireBuffer         | entire buffer as one text object                                                          | \-                                                                                        | \-              |           `gG`           | all                             |
 | nearEoL              | from cursor position to end of line, minus one character                                  | \-                                                                                        | no              |           `n`            | all                             |
-| lineCharacterwise    | current line, but characterwise                                                           | \-                                                                                        | no              |           `_`            | all                             |
+| lineCharacterwise    | current line, but characterwise                                                           | outer includes indentation and trailing spaces                                            | no              |        `i_`, `a_`        | all                             |
 | column               | column down until indent or shorter line. Accepts `{count}` for multiple columns.         | \-                                                                                        | no              |           `\|`           | all                             |
 | value                | value of key-value pair, or right side of a variable assignment (inside one line)         | outer includes trailing commas or semicolons                                              | yes             |        `iv`, `av`        | all                             |
 | key                  | key of key-value pair, or left side of a variable assignment                              | outer includes the `=` or `:`                                                             | yes             |        `ik`, `ak`        | all                             |
@@ -140,7 +140,8 @@ keymap({ "o", "x" }, "YOUR_MAPPING", "<cmd>lua require('various-textobjs').entir
 
 keymap({ "o", "x" }, "YOUR_MAPPING", "<cmd>lua require('various-textobjs').nearEoL()<CR>")
 
-keymap({ "o", "x" }, "YOUR_MAPPING", "<cmd>lua require('various-textobjs').lineCharacterwise()<CR>")
+keymap({ "o", "x" }, "YOUR_MAPPING", "<cmd>lua require('various-textobjs').lineCharacterwise(true)<CR>")
+keymap({ "o", "x" }, "YOUR_MAPPING", "<cmd>lua require('various-textobjs').lineCharacterwise(false)<CR>")
 
 keymap({ "o", "x" }, "YOUR_MAPPING", "<cmd>lua require('various-textobjs').column()<CR>")
 

--- a/doc/various-textobjs.txt
+++ b/doc/various-textobjs.txt
@@ -65,8 +65,9 @@ LIST OF TEXT OBJECTS*various-textobjs-nvim-various-textobjs--list-of-text-object
                          end of line, minus one                                                      
                          character                                                                   
 
-  lineCharacterwise      current line, but       -                       no                    _     all
-                         characterwise                                                               
+  lineCharacterwise      current line, but       outer includes          no                 i_, a_   all
+                         characterwise           indentation and                                     
+                                                 trailing spaces
 
   column                 column down until       -                       no                   \|     all
                          indent or shorter line.                                                     
@@ -223,7 +224,8 @@ For your convenience, here the code to create mappings for all text objects. You
     
     keymap({ "o", "x" }, "YOUR_MAPPING", "<cmd>lua require('various-textobjs').nearEoL()<CR>")
     
-    keymap({ "o", "x" }, "YOUR_MAPPING", "<cmd>lua require('various-textobjs').lineCharacterwise()<CR>")
+    keymap({ "o", "x" }, "YOUR_MAPPING", "<cmd>lua require('various-textobjs').lineCharacterwise(true)<CR>")
+    keymap({ "o", "x" }, "YOUR_MAPPING", "<cmd>lua require('various-textobjs').lineCharacterwise(false)<CR>")
     
     keymap({ "o", "x" }, "YOUR_MAPPING", "<cmd>lua require('various-textobjs').column()<CR>")
     

--- a/lua/various-textobjs/charwise-textobjs.lua
+++ b/lua/various-textobjs/charwise-textobjs.lua
@@ -126,9 +126,14 @@ function M.nearEoL()
 end
 
 ---current line (but characterwise)
-function M.lineCharacterwise()
+---@param inner boolean outer includes indentation and trailing spaces
+function M.lineCharacterwise(inner)
 	if not isVisualMode() then u.normal("v") end
-	u.normal("g_o^")
+	if inner then
+		u.normal("g_o^")
+	else
+		u.normal("$o0")
+	end
 end
 
 ---similar to https://github.com/andrewferrier/textobj-diagnostic.nvim

--- a/lua/various-textobjs/charwise-textobjs.lua
+++ b/lua/various-textobjs/charwise-textobjs.lua
@@ -128,11 +128,15 @@ end
 ---current line (but characterwise)
 ---@param inner boolean outer includes indentation and trailing spaces
 function M.lineCharacterwise(inner)
+	if fn.col("$") == 1 then -- edge case: empty line
+		return
+	end
+
 	if not isVisualMode() then u.normal("v") end
 	if inner then
 		u.normal("g_o^")
 	else
-		u.normal("$o0")
+		u.normal("$ho0")
 	end
 end
 

--- a/lua/various-textobjs/default-keymaps.lua
+++ b/lua/various-textobjs/default-keymaps.lua
@@ -8,11 +8,11 @@ local innerOuterMaps = {
 	subword = "S", -- lowercase taken for sentence textobj
 	closedFold = "z", -- z is the common prefix for folds
 	chainMember = "m",
+	lineCharacterwise = "_",
 }
 local oneMaps = {
 	nearEoL = "n",
 	visibleInWindow = "gw",
-	lineCharacterwise = "_",
 	toNextClosingBracket = "%", -- since this is basically a more intuitive version of the standard "%" motion-as-textobj
 	restOfParagraph = "r",
 	restOfIndentation = "R",

--- a/lua/various-textobjs/default-keymaps.lua
+++ b/lua/various-textobjs/default-keymaps.lua
@@ -60,13 +60,13 @@ function M.setup()
 		keymap(
 			{ "o", "x" },
 			"a" .. map,
-			"<cmd>lua require('various-textobjs')." .. objName .. "(true)<CR>",
+			"<cmd>lua require('various-textobjs')." .. objName .. "(false)<CR>",
 			{ desc = "outer" .. name }
 		)
 		keymap(
 			{ "o", "x" },
 			"i" .. map,
-			"<cmd>lua require('various-textobjs')." .. objName .. "(false)<CR>",
+			"<cmd>lua require('various-textobjs')." .. objName .. "(true)<CR>",
 			{ desc = "inner" .. name }
 		)
 	end

--- a/lua/various-textobjs/init.lua
+++ b/lua/various-textobjs/init.lua
@@ -82,7 +82,7 @@ function M.nearEoL() charwise.nearEoL() end
 function M.toNextClosingBracket() charwise.toNextClosingBracket(lookForwardSmall) end
 
 ---current line (but characterwise)
-function M.lineCharacterwise() charwise.lineCharacterwise() end
+function M.lineCharacterwise(inner) charwise.lineCharacterwise(inner) end
 
 ---diagnostic text object
 ---similar to https://github.com/andrewferrier/textobj-diagnostic.nvim


### PR DESCRIPTION
- `i_` selects inner line, without indentation and trailing spaces
- `a_` selects entire line

I've also swapped boolean values used to create inner/outer mappings, because textobjects functions require `inner` argument that is true when the keymap starts with `i`