### PR TITLE
Fix column() motion when already in visual block mode

### DIFF
--- a/lua/various-textobjs/blockwise-textobjs.lua
+++ b/lua/various-textobjs/blockwise-textobjs.lua
@@ -22,7 +22,7 @@ function M.column()
 	local linesDown = nextLnum - 1 - startRow
 
 	-- start visual block mode
-	if not (fn.mode() == "CTRL-V") then vim.cmd.execute([["normal! \<C-v>"]]) end
+	if not (fn.mode() == "") then vim.cmd.execute([["normal! \<C-v>"]]) end
 
 	-- set position
 	-- not using `setCursor`, since its column-positions are messed up by tab indentation


### PR DESCRIPTION
`vim.fn.mode()` returns CTRL-V as one character, see https://neovim.io/doc/user/builtin.html#mode()

This PR replaces `CTRL-V` with the character `^V` in the column() motion.