### PR TITLE
add number to example keymaps in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,9 @@ keymap({ "o", "x" }, "YOUR_MAPPING", "<cmd>lua require('various-textobjs').key(f
 
 keymap({ "o", "x" }, "YOUR_MAPPING", "<cmd>lua require('various-textobjs').url()<CR>")
 
+keymap({ "o", "x" }, "YOUR_MAPPING", "<cmd>lua require('various-textobjs').number(true)<CR>")
+keymap({ "o", "x" }, "YOUR_MAPPING", "<cmd>lua require('various-textobjs').number(false)<CR>")
+
 keymap({ "o", "x" }, "YOUR_MAPPING", "<cmd>lua require('various-textobjs').diagnostic()<CR>")
 
 keymap({ "o", "x" }, "YOUR_MAPPING", "<cmd>lua require('various-textobjs').closedFold(true)<CR>")


### PR DESCRIPTION
This is helpful because it shows `numbers` accepts a true/false parameter.