### PR TITLE
Fix indentation default keymap

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ local keymap = vim.keymap.set
 
 keymap({ "o", "x" }, "ii", "<cmd>lua require('various-textobjs').indentation('inner', 'inner')<CR>")
 keymap({ "o", "x" }, "ai", "<cmd>lua require('various-textobjs').indentation('outer', 'inner')<CR>")
-keymap({ "o", "x" }, "iI", "<cmd>lua require('various-textobjs').indentation('inner', 'inner')<CR>")
+keymap({ "o", "x" }, "iI", "<cmd>lua require('various-textobjs').indentation('inner', 'outer')<CR>")
 keymap({ "o", "x" }, "aI", "<cmd>lua require('various-textobjs').indentation('outer', 'outer')<CR>")
 
 keymap({ "o", "x" }, "YOUR_MAPPING", "<cmd>lua require('various-textobjs').restOfIndentation()<CR>")

--- a/lua/various-textobjs/default-keymaps.lua
+++ b/lua/various-textobjs/default-keymaps.lua
@@ -87,7 +87,7 @@ function M.setup(disabled_keymaps)
 	-- stylua: ignore start
 	keymap( { "o", "x" }, "ii" , "<cmd>lua require('various-textobjs').indentation('inner', 'inner')<CR>", { desc = "inner-inner indentation textobj" })
 	keymap( { "o", "x" }, "ai" , "<cmd>lua require('various-textobjs').indentation('outer', 'inner')<CR>", { desc = "outer-inner indentation textobj" })
-	keymap( { "o", "x" }, "iI" , "<cmd>lua require('various-textobjs').indentation('inner', 'inner')<CR>", { desc = "inner-inner indentation textobj" })
+	keymap( { "o", "x" }, "iI" , "<cmd>lua require('various-textobjs').indentation('inner', 'outer')<CR>", { desc = "inner-outer indentation textobj" })
 	keymap( { "o", "x" }, "aI" , "<cmd>lua require('various-textobjs').indentation('outer', 'outer')<CR>", { desc = "outer-outer indentation textobj" })
 
 	vim.api.nvim_create_augroup("VariousTextobjs", {})


### PR DESCRIPTION
Both `ii` and `iI` had the same keymap.