### PR TITLE
feature: add blanklines option to indentation textobject

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,13 @@ vim.keymap.set(
 	"ai",
 	'<cmd>lua require("various-textobjs").indentation("outer", "inner")<CR>'
 )
+
+-- an additional parameter can be passed to control whether blank lines are included
+vim.keymap.set(
+  { "o", "x" },
+  "ai",
+  '<cmd>lua require("various-textobjs").indentation("outer", "inner", "noBlanks")<CR>'
+)
 ```
 
 For your convenience, here the code to create mappings for all text objects. You can copypaste this list and enter your own bindings.

--- a/lua/various-textobjs/init.lua
+++ b/lua/various-textobjs/init.lua
@@ -67,8 +67,11 @@ function M.entireBuffer() linewise.entireBuffer() end
 ---indentation textobj
 ---@param startBorder "inner"|"outer" exclude the startline
 ---@param endBorder "inner"|"outer" exclude the endline
-function M.indentation(startBorder, endBorder)
-	linewise.indentation(argConvert(startBorder), argConvert(endBorder))
+---@param blankLines? "withBlanks"|"noBlanks"
+function M.indentation(startBorder, endBorder, blankLines)
+	local includeBlankLines = true
+	if blankLines == "noBlanks" then includeBlankLines = false end
+	linewise.indentation(argConvert(startBorder), argConvert(endBorder), includeBlankLines)
 end
 
 ---from cursor position down all lines with same or higher indentation;

--- a/lua/various-textobjs/linewise-textobjs.lua
+++ b/lua/various-textobjs/linewise-textobjs.lua
@@ -141,7 +141,8 @@ end
 ---indentation textobj
 ---@param startBorder "inner"|"outer"
 ---@param endBorder "inner"|"outer"
-function M.indentation(startBorder, endBorder)
+---@param includeBlankLines? boolean
+function M.indentation(startBorder, endBorder, includeBlankLines)
 	local curLnum = fn.line(".")
 	local lastLine = fn.line("$")
 	while isBlankLine(curLnum) do -- when on blank line, use next line
@@ -158,10 +159,16 @@ function M.indentation(startBorder, endBorder)
 	local prevLnum = curLnum - 1
 	local nextLnum = curLnum + 1
 
-	while prevLnum > 0 and (isBlankLine(prevLnum) or fn.indent(prevLnum) >= indentOfStart) do
+	while
+		prevLnum > 0
+		and ((includeBlankLines and isBlankLine(prevLnum)) or fn.indent(prevLnum) >= indentOfStart)
+	do
 		prevLnum = prevLnum - 1
 	end
-	while nextLnum <= lastLine and (isBlankLine(nextLnum) or fn.indent(nextLnum) >= indentOfStart) do
+	while
+		nextLnum <= lastLine
+		and ((includeBlankLines and isBlankLine(nextLnum)) or fn.indent(nextLnum) >= indentOfStart)
+	do
 		nextLnum = nextLnum + 1
 	end
 


### PR DESCRIPTION
Default behavior remains the same which includes blanklines.

Setting the new optional additional `indentation`  **_parameter_** to `false` would not include blanklines when selecting indentation.

This would solve #44