### PR TITLE
chore: for `dsi` script, only return if indentation is not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,7 +439,7 @@ vim.keymap.set("n", "dsi", function()
 
 	-- plugin only switches to visual mode when a textobj has been found
 	local indentationFound = vim.fn.mode():find("V")
-	if indentationFound then return end
+	if not indentationFound then return end
 
 	-- dedent indentation
 	vim.cmd.normal { "<", bang = true }


### PR DESCRIPTION
## Checklist
- [x] Used only camelCase variable names.
- [x] If functionality is added or modified, also made respective changes to the readme.
- [x] Used conventional commits keywords.
