### PR TITLE
feat: match quote at the start of a line

### DIFF
--- a/lua/various-textobjs/charwise-textobjs.lua
+++ b/lua/various-textobjs/charwise-textobjs.lua
@@ -179,6 +179,9 @@ function M.anyQuote(scope, lookForwL)
 	-- the off-chance that the user has customized this.
 	local escape = vim.opt_local.quoteescape:get() -- default: \
 	local patterns = {
+		('^(").-[^%s](")'):format(escape, escape), -- ""
+		("^(').-[^%s](')"):format(escape, escape), -- ''
+		("^(`).-[^%s](`)"):format(escape, escape), -- ``
 		('([^%s]").-[^%s](")'):format(escape, escape), -- ""
 		("([^%s]').-[^%s](')"):format(escape, escape), -- ''
 		("([^%s]`).-[^%s](`)"):format(escape, escape), -- ``


### PR DESCRIPTION
## Checklist
- [x] Used only camelCase variable names.
- [x] If functionality is added or modified, also made respective changes to the readme.
- [x] Used conventional commits keywords.

This allows matching the lines:

```
"abc"
"abc" 123
'abc'
'abc' 123
`abc`
`abc` 123
```