### PR TITLE
refactor: remove redundant argument

### DIFF
--- a/lua/various-textobjs/charwise-textobjs.lua
+++ b/lua/various-textobjs/charwise-textobjs.lua
@@ -179,9 +179,9 @@ function M.anyQuote(scope, lookForwL)
 	-- the off-chance that the user has customized this.
 	local escape = vim.opt_local.quoteescape:get() -- default: \
 	local patterns = {
-		('^(").-[^%s](")'):format(escape, escape), -- ""
-		("^(').-[^%s](')"):format(escape, escape), -- ''
-		("^(`).-[^%s](`)"):format(escape, escape), -- ``
+		('^(").-[^%s](")'):format(escape), -- ""
+		("^(').-[^%s](')"):format(escape), -- ''
+		("^(`).-[^%s](`)"):format(escape), -- ``
 		('([^%s]").-[^%s](")'):format(escape, escape), -- ""
 		("([^%s]').-[^%s](')"):format(escape, escape), -- ''
 		("([^%s]`).-[^%s](`)"):format(escape, escape), -- ``


### PR DESCRIPTION
## Checklist
- [x] Used only camelCase variable names.
- [x] If functionality is added or modified, also made respective changes to the readme.
- [x] Used conventional commits keywords.

Small thing I missed before.