### PR TITLE
fix: use `abs()` so distance is always non-negative

### DIFF
--- a/lua/various-textobjs/charwise-textobjs.lua
+++ b/lua/various-textobjs/charwise-textobjs.lua
@@ -99,14 +99,8 @@ local function selectTextobj(patterns, scope, lookForwL)
 			local startPos, endPos = searchTextobj(pattern, scope, lookForwL)
 			if startPos and endPos then
 				local row, startCol = unpack(startPos)
-				local distance = startCol - cursorCol
+				local distance = vim.fn.abs(startCol - cursorCol)
 				local isCloserInRow = distance < shortestDist
-
-				local cursorOnCurrentObj = (distance < 0)
-				local cursorOnClosestObj = (shortestDist < 0)
-				if cursorOnCurrentObj and cursorOnClosestObj then
-					isCloserInRow = distance > shortestDist
-				end
 
 				-- this condition for rows suffices since `searchTextobj` does not
 				-- return multi-line-objects


### PR DESCRIPTION
## Checklist
- [x] Used only camelCase variable names.
- [x] If functionality is added or modified, also made respective changes to the readme.
- [x] Used conventional commits keywords.

I'm not entirely sure what the existing code's condition is doing. For the following example, where I press `yie`, it gives `a* *b`, instead of `b`. If it just matches the pattern closest to the cursor, it works.

```markdown
*a* *|b*
```

(`|` shows the cursor position.)

Using `vim.fn.abs()` appears to fix this. Does this make sense?

Of course, ideally `a* *b` would never be matched as the contents of an emphasis anyway, but I don't think *Lua* patterns are powerful enough for this.