### PR TITLE
refactor: improve comparison of `selectTextobj()`

### DIFF
--- a/lua/various-textobjs/utils.lua
+++ b/lua/various-textobjs/utils.lua
@@ -1,6 +1,22 @@
 local M = {}
 --------------------------------------------------------------------------------
 
+---compares two tuples lexicographically
+---@param xs1 table
+---@param xs2 table
+---@return number
+function M.compareTuples(xs1, xs2)
+	for i, x1 in ipairs(xs1) do
+		local x2 = xs2[i]
+		if x1 > x2 then
+			return 1
+		elseif x1 < x2 then
+			return -1
+		end
+	end
+	return 0
+end
+
 ---runs :normal natively with bang
 ---@param cmdStr any
 function M.normal(cmdStr)


### PR DESCRIPTION
## Checklist
- [x] Used only camelCase variable names.
- [x] If functionality is added or modified, also made respective changes to the readme.
- [x] Used conventional commits keywords.

This compares:

- If cursor is on the text object.
- Distance between cursor row and text object row.
- Distance between cursor start col and text object start col.
- Distance between cursor end col and text object end col.

It now works for the test case:

```markdown
*a* *|b*
```

`yie` now selects `b`.