### PR TITLE
feat: option to disable 

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,9 @@ require("various-textobjs").setup {
 
 	-- disable only some default keymaps, e.g. { "ai", "ii" }
 	disabledKeymaps = {},
+
+	-- display notifications if a text object is not found
+	notifyNotFound = true,
 }
 ```
 

--- a/lua/various-textobjs/charwise-textobjs.lua
+++ b/lua/various-textobjs/charwise-textobjs.lua
@@ -319,7 +319,7 @@ end
 -- INFO mastodon URLs contain `@`, neovim docs urls can contain a `'`
 M.urlPattern = "%l%l%l-://[A-Za-z0-9_%-/.#%%=?&'@+]+"
 
-function M.url() M.selectTextobj(M.urlPattern, "outer", config.lookForwardSmall) end
+function M.url() M.selectTextobj(M.urlPattern, "outer", config.lookForwardBig) end
 
 ---see #26
 ---@param scope "inner"|"outer" inner excludes the leading dot

--- a/lua/various-textobjs/charwise-textobjs.lua
+++ b/lua/various-textobjs/charwise-textobjs.lua
@@ -1,6 +1,8 @@
 local M = {}
 local u = require("various-textobjs.utils")
 local getCursor = vim.api.nvim_win_get_cursor
+local config = require("various-textobjs.config").config
+
 --------------------------------------------------------------------------------
 
 ---@return boolean
@@ -152,13 +154,12 @@ function M.subword(scope)
 	M.selectTextobj(pattern, scope, 0)
 end
 
----@param lookForwL integer
-function M.toNextClosingBracket(lookForwL)
+function M.toNextClosingBracket()
 	local pattern = "().([]})])"
 
-	local _, endPos = M.searchTextobj(pattern, "inner", lookForwL)
+	local _, endPos = M.searchTextobj(pattern, "inner", config.lookForwardSmall)
 	if not endPos then
-		u.notFoundMsg(lookForwL)
+		u.notFoundMsg(config.lookForwardSmall)
 		return
 	end
 	local startPos = getCursor(0)
@@ -166,16 +167,15 @@ function M.toNextClosingBracket(lookForwL)
 	M.setSelection(startPos, endPos)
 end
 
----@param lookForwL integer
-function M.toNextQuotationMark(lookForwL)
+function M.toNextQuotationMark()
 	-- char before quote must not be escape char. Using `vim.opt.quoteescape` on
 	-- the off-chance that the user has customized this.
 	local quoteEscape = vim.opt_local.quoteescape:get() -- default: \
 	local pattern = ([[()[^%s](["'`])]]):format(quoteEscape)
 
-	local _, endPos = M.searchTextobj(pattern, "inner", lookForwL)
+	local _, endPos = M.searchTextobj(pattern, "inner", config.lookForwardSmall)
 	if not endPos then
-		u.notFoundMsg(lookForwL)
+		u.notFoundMsg(config.lookForwardSmall)
 		return
 	end
 	local startPos = getCursor(0)
@@ -184,8 +184,7 @@ function M.toNextQuotationMark(lookForwL)
 end
 
 ---@param scope "inner"|"outer"
----@param lookForwL integer
-function M.anyQuote(scope, lookForwL)
+function M.anyQuote(scope)
 	-- INFO char before quote must not be escape char. Using `vim.opt.quoteescape` on
 	-- the off-chance that the user has customized this.
 	local escape = vim.opt_local.quoteescape:get() -- default: \
@@ -198,7 +197,7 @@ function M.anyQuote(scope, lookForwL)
 		("([^%s]`).-[^%s](`)"):format(escape, escape), -- ``
 	}
 
-	M.selectTextobj(patterns, scope, lookForwL)
+	M.selectTextobj(patterns, scope, config.lookForwardSmall)
 
 	-- pattern accounts for escape char, so move to right to account for that
 	local isAtStart = vim.api.nvim_win_get_cursor(0)[2] == 1
@@ -206,14 +205,13 @@ function M.anyQuote(scope, lookForwL)
 end
 
 ---@param scope "inner"|"outer"
----@param lookForwL integer
-function M.anyBracket(scope, lookForwL)
+function M.anyBracket(scope)
 	local patterns = {
 		"(%().-(%))", -- ()
 		"(%[).-(%])", -- []
 		"({).-(})", -- {}
 	}
-	M.selectTextobj(patterns, scope, lookForwL)
+	M.selectTextobj(patterns, scope, config.lookForwardSmall)
 end
 
 ---near end of the line, ignoring trailing whitespace
@@ -271,16 +269,15 @@ function M.diagnostic(wrap)
 end
 
 ---@param scope "inner"|"outer" inner value excludes trailing commas or semicolons, outer includes them. Both exclude trailing comments.
----@param lookForwL integer
-function M.value(scope, lookForwL)
+function M.value(scope)
 	-- captures value till the end of the line
 	-- negative sets and frontier pattern ensure that equality comparators ==, !=
 	-- or css pseudo-elements :: are not matched
 	local pattern = "(%s*%f[!<>~=:][=:]%s*)[^=:].*()"
 
-	local startPos, endPos = M.searchTextobj(pattern, scope, lookForwL)
+	local startPos, endPos = M.searchTextobj(pattern, scope, config.lookForwardSmall)
 	if not startPos or not endPos then
-		u.notFoundMsg(lookForwL)
+		u.notFoundMsg(config.lookForwardSmall)
 		return
 	end
 
@@ -304,37 +301,31 @@ function M.value(scope, lookForwL)
 end
 
 ---@param scope "inner"|"outer" outer key includes the `:` or `=` after the key
----@param lookForwL integer
-function M.key(scope, lookForwL)
+function M.key(scope)
 	local pattern = "()%S.-( ?[:=] ?)"
-	M.selectTextobj(pattern, scope, lookForwL)
+	M.selectTextobj(pattern, scope, config.lookForwardSmall)
 end
 
 ---@param scope "inner"|"outer" inner number consists purely of digits, outer number factors in decimal points and includes minus sign
----@param lookForwL integer
-function M.number(scope, lookForwL)
+function M.number(scope)
 	-- Here two different patterns make more sense, so the inner number can match
 	-- before and after the decimal dot. enforcing digital after dot so outer
 	-- excludes enumrations.
 	local pattern = scope == "inner" and "%d+" or "%-?%d*%.?%d+"
-	M.selectTextobj(pattern, "outer", lookForwL)
+	M.selectTextobj(pattern, "outer", config.lookForwardSmall)
 end
 
 -- make URL pattern available for external use
 -- INFO mastodon URLs contain `@`, neovim docs urls can contain a `'`
 M.urlPattern = "%l%l%l-://[A-Za-z0-9_%-/.#%%=?&'@+]+"
 
----@param lookForwL integer
-function M.url(lookForwL)
-	M.selectTextobj(M.urlPattern, "outer", lookForwL)
-end
+function M.url() M.selectTextobj(M.urlPattern, "outer", config.lookForwardSmall) end
 
 ---see #26
 ---@param scope "inner"|"outer" inner excludes the leading dot
----@param lookForwL integer
-function M.chainMember(scope, lookForwL)
+function M.chainMember(scope)
 	local pattern = "(%.)[%w_][%a_]*%b()()"
-	M.selectTextobj(pattern, scope, lookForwL)
+	M.selectTextobj(pattern, scope, config.lookForwardSmall)
 end
 
 function M.lastChange()
@@ -353,15 +344,13 @@ end
 -- FILETYPE SPECIFIC TEXTOBJS
 
 ---@param scope "inner"|"outer" inner link only includes the link title, outer link includes link, url, and the four brackets.
----@param lookForwL integer
-function M.mdlink(scope, lookForwL)
+function M.mdlink(scope)
 	local pattern = "(%[)[^%]]-(%]%b())"
-	M.selectTextobj(pattern, scope, lookForwL)
+	M.selectTextobj(pattern, scope, config.lookForwardSmall)
 end
 
 ---@param scope "inner"|"outer" inner selector only includes the content, outer selector includes the type.
----@param lookForwL integer
-function M.mdEmphasis(scope, lookForwL)
+function M.mdEmphasis(scope)
 	-- CAVEAT this still has a few edge cases with escaped markup, will need a
 	-- treesitter object to reliably account for that.
 	local patterns = {
@@ -374,7 +363,7 @@ function M.mdEmphasis(scope, lookForwL)
 		"(^==).-[^\\](==)", -- ==
 		"(^~~).-[^\\](~~)", -- ~~
 	}
-	M.selectTextobj(patterns, scope, lookForwL)
+	M.selectTextobj(patterns, scope, config.lookForwardSmall)
 
 	-- pattern accounts for escape char, so move to right to account for that
 	local isAtStart = vim.api.nvim_win_get_cursor(0)[2] == 1
@@ -382,43 +371,38 @@ function M.mdEmphasis(scope, lookForwL)
 end
 
 ---@param scope "inner"|"outer" inner double square brackets exclude the brackets themselves
----@param lookForwL integer
-function M.doubleSquareBrackets(scope, lookForwL)
+function M.doubleSquareBrackets(scope)
 	local pattern = "(%[%[).-(%]%])"
-	M.selectTextobj(pattern, scope, lookForwL)
+	M.selectTextobj(pattern, scope, config.lookForwardSmall)
 end
 
 ---@param scope "inner"|"outer" outer selector includes trailing comma and whitespace
----@param lookForwL integer
-function M.cssSelector(scope, lookForwL)
+function M.cssSelector(scope)
 	local pattern = "()[#.][%w-_]+(,? ?)"
-	M.selectTextobj(pattern, scope, lookForwL)
+	M.selectTextobj(pattern, scope, config.lookForwardSmall)
 end
 
 ---@param scope "inner"|"outer" inner selector is only the value of the attribute inside the quotation marks.
----@param lookForwL integer
-function M.htmlAttribute(scope, lookForwL)
+function M.htmlAttribute(scope)
 	local pattern = [[(%w+=["']).-(["'])]]
-	M.selectTextobj(pattern, scope, lookForwL)
+	M.selectTextobj(pattern, scope, config.lookForwardSmall)
 end
 
 ---@param scope "inner"|"outer" outer selector includes the front pipe
----@param lookForwL integer
-function M.shellPipe(scope, lookForwL)
+function M.shellPipe(scope)
 	local pattern = "()[^|%s][^|]-( ?| ?)"
-	M.selectTextobj(pattern, scope, lookForwL)
+	M.selectTextobj(pattern, scope, config.lookForwardSmall)
 end
 
 ---@param scope "inner"|"outer" inner only affects the color value
----@param lookForwL integer
-function M.cssColor(scope, lookForwL)
+function M.cssColor(scope)
 	local pattern = {
 		"(#)" .. ("%x"):rep(6) .. "()", -- #123456
 		"(#)" .. ("%x"):rep(3) .. "()", -- #123
 		"(hsl%()[%%%d,./deg ]-(%))", -- hsl(123, 23, 23) or hsl(123deg, 123%, 123% / 100)
 		"(rgb%()[%d,./ ]-(%))", -- rgb(123, 123, 123) or rgb(50%, 50%, 50%)
 	}
-	M.selectTextobj(pattern, scope, lookForwL)
+	M.selectTextobj(pattern, scope, config.lookForwardSmall)
 end
 
 ---INFO this textobj requires the python Treesitter parser

--- a/lua/various-textobjs/config.lua
+++ b/lua/various-textobjs/config.lua
@@ -19,10 +19,7 @@ M.config = defaultConfig
 
 ---optional setup function
 ---@param userConfig? config
-function M.setup(userConfig)
-	M.config = vim.tbl_deep_extend("force", M.config, userConfig or {})
-	return M.config
-end
+function M.setup(userConfig) M.config = vim.tbl_deep_extend("force", M.config, userConfig or {}) end
 
 --------------------------------------------------------------------------------
 return M

--- a/lua/various-textobjs/config.lua
+++ b/lua/various-textobjs/config.lua
@@ -1,0 +1,30 @@
+local M = {}
+--------------------------------------------------------------------------------
+---@class config
+---@field lookForwardSmall? number
+---@field lookForwardBig? number
+---@field useDefaultKeymaps? boolean
+---@field disabledKeymaps? string[]
+
+---@type config
+local defaultConfig = {
+	lookForwardSmall = 5,
+	lookForwardBig = 15,
+	useDefaultKeymaps = false,
+	disabledKeymaps = {},
+}
+M.config = defaultConfig
+
+---optional setup function
+---@param userConfig? config
+function M.setup(userConfig)
+	M.config = vim.tbl_deep_extend("force", M.config, userConfig or {})
+
+	if M.config.useDefaultKeymaps then
+		require("various-textobjs.default-keymaps").setup(M.config.disabledKeymaps)
+	end
+	return M.config
+end
+
+--------------------------------------------------------------------------------
+return M

--- a/lua/various-textobjs/config.lua
+++ b/lua/various-textobjs/config.lua
@@ -21,10 +21,6 @@ M.config = defaultConfig
 ---@param userConfig? config
 function M.setup(userConfig)
 	M.config = vim.tbl_deep_extend("force", M.config, userConfig or {})
-
-	if M.config.useDefaultKeymaps then
-		require("various-textobjs.default-keymaps").setup(M.config.disabledKeymaps)
-	end
 	return M.config
 end
 

--- a/lua/various-textobjs/config.lua
+++ b/lua/various-textobjs/config.lua
@@ -5,6 +5,7 @@ local M = {}
 ---@field lookForwardBig? number
 ---@field useDefaultKeymaps? boolean
 ---@field disabledKeymaps? string[]
+---@field notifyNotFound? boolean
 
 ---@type config
 local defaultConfig = {
@@ -12,6 +13,7 @@ local defaultConfig = {
 	lookForwardBig = 15,
 	useDefaultKeymaps = false,
 	disabledKeymaps = {},
+	notifyNotFound = true,
 }
 M.config = defaultConfig
 

--- a/lua/various-textobjs/init.lua
+++ b/lua/various-textobjs/init.lua
@@ -21,25 +21,11 @@ local function argConvert(arg)
 end
 
 --------------------------------------------------------------------------------
----@type config
-local defaultConfig = {
-	lookForwardSmall = 5,
-	lookForwardBig = 15,
-	useDefaultKeymaps = false,
-	disabledKeymaps = {},
-}
-local config = defaultConfig
-
----@class config
----@field lookForwardSmall? number
----@field lookForwardBig? number
----@field useDefaultKeymaps? boolean
----@field disabledKeymaps? string[]
 
 ---optional setup function
 ---@param userConfig? config
 function M.setup(userConfig)
-	config = vim.tbl_deep_extend("force", defaultConfig, userConfig or {})
+	local config = require("various-textobjs.config").setup(userConfig)
 
 	if config.useDefaultKeymaps then
 		require("various-textobjs.default-keymaps").setup(config.disabledKeymaps)
@@ -69,18 +55,12 @@ end
 
 ---@param scope "inner"|"outer" outer adds one line after the fold
 function M.closedFold(scope)
-	require("various-textobjs.linewise-textobjs").closedFold(
-		argConvert(scope),
-		config.lookForwardBig
-	)
+	require("various-textobjs.linewise-textobjs").closedFold(argConvert(scope))
 end
 
 ---@param scope "inner"|"outer" inner excludes the backticks
 function M.mdFencedCodeBlock(scope)
-	require("various-textobjs.linewise-textobjs").mdFencedCodeBlock(
-		argConvert(scope),
-		config.lookForwardBig
-	)
+	require("various-textobjs.linewise-textobjs").mdFencedCodeBlock(argConvert(scope))
 end
 
 ---@param scope "inner"|"outer" inner excludes the `"""`
@@ -111,47 +91,31 @@ function M.lineCharacterwise(scope)
 	require("various-textobjs.charwise-textobjs").lineCharacterwise(argConvert(scope))
 end
 function M.toNextClosingBracket()
-	require("various-textobjs.charwise-textobjs").toNextClosingBracket(config.lookForwardSmall)
+	require("various-textobjs.charwise-textobjs").toNextClosingBracket()
 end
-function M.toNextQuotationMark()
-	require("various-textobjs.charwise-textobjs").toNextQuotationMark(config.lookForwardSmall)
-end
-function M.url() require("various-textobjs.charwise-textobjs").url(config.lookForwardBig) end
+function M.toNextQuotationMark() require("various-textobjs.charwise-textobjs").toNextQuotationMark() end
+function M.url() require("various-textobjs.charwise-textobjs").url() end
 
 ---@param wrap "wrap"|"nowrap"
 function M.diagnostic(wrap) require("various-textobjs.charwise-textobjs").diagnostic(wrap) end
 function M.lastChange() require("various-textobjs.charwise-textobjs").lastChange() end
 
 ---@param scope "inner"|"outer"
-function M.anyQuote(scope)
-	require("various-textobjs.charwise-textobjs").anyQuote(
-		argConvert(scope),
-		config.lookForwardSmall
-	)
-end
+function M.anyQuote(scope) require("various-textobjs.charwise-textobjs").anyQuote(argConvert(scope)) end
 
 ---@param scope "inner"|"outer"
 function M.anyBracket(scope)
-	require("various-textobjs.charwise-textobjs").anyBracket(
-		argConvert(scope),
-		config.lookForwardSmall
-	)
+	require("various-textobjs.charwise-textobjs").anyBracket(argConvert(scope))
 end
 
 ---@param scope "inner"|"outer" inner value excludes trailing commas or semicolons, outer includes them. Both exclude trailing comments.
-function M.value(scope)
-	require("various-textobjs.charwise-textobjs").value(argConvert(scope), config.lookForwardSmall)
-end
+function M.value(scope) require("various-textobjs.charwise-textobjs").value(argConvert(scope)) end
 
 ---@param scope "inner"|"outer" outer key includes the `:` or `=` after the key
-function M.key(scope)
-	require("various-textobjs.charwise-textobjs").key(argConvert(scope), config.lookForwardSmall)
-end
+function M.key(scope) require("various-textobjs.charwise-textobjs").key(argConvert(scope)) end
 
 ---@param scope "inner"|"outer" inner number consists purely of digits, outer number factors in decimal points and includes minus sign
-function M.number(scope)
-	require("various-textobjs.charwise-textobjs").number(argConvert(scope), config.lookForwardSmall)
-end
+function M.number(scope) require("various-textobjs.charwise-textobjs").number(argConvert(scope)) end
 
 ---@param scope "inner"|"outer" outer includes trailing -_
 function M.subword(scope) require("various-textobjs.charwise-textobjs").subword(argConvert(scope)) end
@@ -159,66 +123,41 @@ function M.subword(scope) require("various-textobjs.charwise-textobjs").subword(
 ---see #26
 ---@param scope "inner"|"outer" inner excludes the leading dot
 function M.chainMember(scope)
-	require("various-textobjs.charwise-textobjs").chainMember(
-		argConvert(scope),
-		config.lookForwardSmall
-	)
+	require("various-textobjs.charwise-textobjs").chainMember(argConvert(scope))
 end
 
 --------------------------------------------------------------------------------
 -- FILETYPE SPECIFIC TEXTOBJS
 
 ---@param scope "inner"|"outer" inner link only includes the link title, outer link includes link, url, and the four brackets.
-function M.mdlink(scope)
-	require("various-textobjs.charwise-textobjs").mdlink(argConvert(scope), config.lookForwardSmall)
-end
+function M.mdlink(scope) require("various-textobjs.charwise-textobjs").mdlink(argConvert(scope)) end
 
 ---@param scope "inner"|"outer" inner selector only includes the content, outer selector includes the type.
 function M.mdEmphasis(scope)
-	require("various-textobjs.charwise-textobjs").mdEmphasis(
-		argConvert(scope),
-		config.lookForwardSmall
-	)
+	require("various-textobjs.charwise-textobjs").mdEmphasis(argConvert(scope))
 end
 
 ---@param scope "inner"|"outer" inner double square brackets exclude the brackets themselves
 function M.doubleSquareBrackets(scope)
-	require("various-textobjs.charwise-textobjs").doubleSquareBrackets(
-		argConvert(scope),
-		config.lookForwardSmall
-	)
+	require("various-textobjs.charwise-textobjs").doubleSquareBrackets(argConvert(scope))
 end
 
 ---@param scope "inner"|"outer" outer selector includes trailing comma and whitespace
 function M.cssSelector(scope)
-	require("various-textobjs.charwise-textobjs").cssSelector(
-		argConvert(scope),
-		config.lookForwardSmall
-	)
+	require("various-textobjs.charwise-textobjs").cssSelector(argConvert(scope))
 end
 
 ---@param scope "inner"|"outer"
-function M.cssColor(scope)
-	require("various-textobjs.charwise-textobjs").cssColor(
-		argConvert(scope),
-		config.lookForwardSmall
-	)
-end
+function M.cssColor(scope) require("various-textobjs.charwise-textobjs").cssColor(argConvert(scope)) end
 
 ---@param scope "inner"|"outer" inner selector is only the value of the attribute inside the quotation marks.
 function M.htmlAttribute(scope)
-	require("various-textobjs.charwise-textobjs").htmlAttribute(
-		argConvert(scope),
-		config.lookForwardSmall
-	)
+	require("various-textobjs.charwise-textobjs").htmlAttribute(argConvert(scope))
 end
 
 ---@param scope "inner"|"outer" outer selector includes the front pipe
 function M.shellPipe(scope)
-	require("various-textobjs.charwise-textobjs").shellPipe(
-		argConvert(scope),
-		config.lookForwardSmall
-	)
+	require("various-textobjs.charwise-textobjs").shellPipe(argConvert(scope))
 end
 
 --------------------------------------------------------------------------------

--- a/lua/various-textobjs/init.lua
+++ b/lua/various-textobjs/init.lua
@@ -25,7 +25,8 @@ end
 ---optional setup function
 ---@param userConfig? config
 function M.setup(userConfig)
-	local config = require("various-textobjs.config").setup(userConfig)
+	require("various-textobjs.config").setup(userConfig)
+	local config = require("various-textobjs.config").config
 
 	if config.useDefaultKeymaps then
 		require("various-textobjs.default-keymaps").setup(config.disabledKeymaps)

--- a/lua/various-textobjs/linewise-textobjs.lua
+++ b/lua/various-textobjs/linewise-textobjs.lua
@@ -4,6 +4,7 @@ local M = {}
 local fn = vim.fn
 local a = vim.api
 local getCursor = vim.api.nvim_win_get_cursor
+local config = require("various-textobjs.config").config
 
 --------------------------------------------------------------------------------
 
@@ -36,8 +37,7 @@ end
 
 -- next *closed* fold
 ---@param scope "inner"|"outer" outer adds one line after the fold
----@param lookForwL integer number of lines to look forward for the textobj
-function M.closedFold(scope, lookForwL)
+function M.closedFold(scope)
 	local startLnum = getCursor(0)[1]
 	local lastLine = a.nvim_buf_line_count(0)
 	local startedOnFold = fn.foldclosed(startLnum) > 0
@@ -49,8 +49,8 @@ function M.closedFold(scope, lookForwL)
 	else
 		foldStart = startLnum
 		repeat
-			if foldStart >= lastLine or foldStart > (lookForwL + startLnum) then
-				u.notFoundMsg(lookForwL)
+			if foldStart >= lastLine or foldStart > (config.lookForwardBig + startLnum) then
+				u.notFoundMsg(config.lookForwardBig)
 				return
 			end
 			foldStart = foldStart + 1
@@ -93,8 +93,7 @@ end
 
 ---Md Fenced Code Block Textobj
 ---@param scope "inner"|"outer" inner excludes the backticks
----@param lookForwL integer number of lines to look forward for the textobj
-function M.mdFencedCodeBlock(scope, lookForwL)
+function M.mdFencedCodeBlock(scope)
 	local cursorLnum = getCursor(0)[1]
 	local codeBlockPattern = "^```%w*$"
 
@@ -121,12 +120,13 @@ function M.mdFencedCodeBlock(scope, lookForwL)
 	repeat
 		j = j + 1
 		if j > #cbBegin then
-			u.notFoundMsg(lookForwL)
+			u.notFoundMsg(config.lookForwardBig)
 			return
 		end
 		local cursorInBetween = (cbBegin[j] <= cursorLnum) and (cbEnd[j] >= cursorLnum)
 		-- seek forward for a codeblock
-		local cursorInFront = (cbBegin[j] > cursorLnum) and (cbBegin[j] <= cursorLnum + lookForwL)
+		local cursorInFront = (cbBegin[j] > cursorLnum)
+			and (cbBegin[j] <= cursorLnum + config.lookForwardBig)
 	until cursorInBetween or cursorInFront
 
 	local start = cbBegin[j]

--- a/lua/various-textobjs/utils.lua
+++ b/lua/various-textobjs/utils.lua
@@ -28,6 +28,7 @@ end
 ---notification when no textobj could be found
 ---@param lookForwL integer number of lines the plugin tried to look forward
 function M.notFoundMsg(lookForwL)
+	if not require("various-textobjs.config").config.notifyNotFound then return end
 	local msg = "Textobject not found within the next " .. tostring(lookForwL) .. " lines."
 	if lookForwL == 1 then msg = msg:gsub("s%.$", ".") end -- remove plural s
 	M.notify(msg, "warn")


### PR DESCRIPTION
Refactors config into a new file and then adds the option of `notifyNotFound` (default of `true`) to allow disabling the notification.

- Moved `init.lua` configuration &rarr; `configuration.lua`
- Added `notifyNotFound` to configuration (default: `true`)

Example:

https://github.com/chrisgrieser/nvim-various-textobjs/assets/109556932/0e8fbfd6-af61-4935-b136-3eb545711c24

## Checklist
- [x] Used only camelCase variable names.
- [x] If functionality is added or modified, also made respective changes to the
  README.md (the `.txt` file is auto-generated and does not need to be modified).
- [x] Used conventional commits keywords.