### PR TITLE
fix: always save last position before jump

### DIFF
--- a/lua/various-textobjs/blockwise-textobjs.lua
+++ b/lua/various-textobjs/blockwise-textobjs.lua
@@ -24,6 +24,9 @@ function M.column()
 	until hitsIndent or shorterLine
 	local linesDown = nextLnum - 1 - startRow
 
+	-- save last position in jumplist
+	u.normal("m`")
+
 	-- start visual block mode
 	-- INFO requires special character `^V`
 	if not (fn.mode() == "") then vim.cmd.execute([["normal! \<C-v>"]]) end

--- a/lua/various-textobjs/charwise-textobjs.lua
+++ b/lua/various-textobjs/charwise-textobjs.lua
@@ -18,6 +18,8 @@ end
 ---@param startPos pos
 ---@param endPos pos
 function M.setSelection(startPos, endPos)
+	-- save last position in jumplist
+	u.normal("m`")
 	vim.api.nvim_win_set_cursor(0, startPos)
 	if isVisualMode() then
 		u.normal("o")

--- a/lua/various-textobjs/linewise-textobjs.lua
+++ b/lua/various-textobjs/linewise-textobjs.lua
@@ -18,6 +18,8 @@ end
 ---@param startline integer
 ---@param endline integer
 local function setLinewiseSelection(startline, endline)
+	-- save last position in jumplist (see #86)
+	u.normal("m`")
 	a.nvim_win_set_cursor(0, { startline, 0 })
 	if not isVisualLineMode() then u.normal("V") end
 	u.normal("o")


### PR DESCRIPTION
## Checklist
- [x] Used only camelCase variable names.
- [x] If functionality is added or modified, also made respective changes to the
  README.md (the `.txt` file is auto-generated and does not need to be modified).
- [x] Used conventional commits keywords.
