### PR TITLE
fix: `mdFencedCodeBlock` on last incomplete codeblock

### DIFF
--- a/lua/various-textobjs/linewise-textobjs.lua
+++ b/lua/various-textobjs/linewise-textobjs.lua
@@ -113,7 +113,7 @@ function M.mdFencedCodeBlock(scope)
 		i = i + 1
 	end
 
-	if #cbBegin > #cbEnd then table.remove(cbEnd) end -- incomplete codeblock
+	if #cbBegin > #cbEnd then table.remove(cbBegin) end -- incomplete codeblock
 
 	-- determine cursor location in a codeblock
 	local j = 0


### PR DESCRIPTION
To reproduce, input only one <code>```</code> in a markdown file then run `mdFencedCodeBlock`.