### PR TITLE
fix: correct string concatenation in deprecation warning

### DIFF
--- a/lua/various-textobjs/init.lua
+++ b/lua/various-textobjs/init.lua
@@ -17,7 +17,7 @@ local function argConvert(arg)
 	local u = require("various-textobjs.utils")
 	if not notifiedOnce and (arg == false or arg == true) then
 		local msg = "`true` and `false` are deprecated as textobject arguments. "
-			+ 'Use `"inner"` or `"outer"` instead.'
+			.. 'Use `"inner"` or `"outer"` instead.'
 		u.notify(msg, "warn")
 		notifiedOnce = true
 	end


### PR DESCRIPTION
## Checklist
- [ ] ~Used only camelCase variable names.~
- [ ] ~If functionality is added or modified, also made respective changes to the README.md (the `.txt` file is auto-generated and does not need to be modified).~
- [ ] ~Used conventional commits keywords.~
