### PR TITLE
fix: filetype specific keybinds sometimes break

### DIFF
--- a/lua/various-textobjs/default-keymaps.lua
+++ b/lua/various-textobjs/default-keymaps.lua
@@ -107,9 +107,10 @@ function M.setup(disabled_keymaps)
 	keymap( { "o", "x" }, "aI" , "<cmd>lua require('various-textobjs').indentation('outer', 'outer')<CR>", { desc = "outer-outer indentation textobj" })
 	-- stylua: ignore end
 
+	vim.api.nvim_create_augroup("VariousTextobjs", {})
 	for _, textobj in pairs(ftMaps) do
 		vim.api.nvim_create_autocmd("FileType", {
-			group = vim.api.nvim_create_augroup("VariousTextobjs", {}),
+			group = "VariousTextobjs",
 			pattern = textobj.fts,
 			callback = function()
 				for objName, map in pairs(textobj.map) do


### PR DESCRIPTION
Filetype specific keybinds, like `viC`, don't always work in *Markdown* files anymore.

A minimal reproducible config:

```lua
vim.cmd('colorscheme elflord')

local lazypath = vim.fn.stdpath('data') .. '/lazy/lazy.nvim'
if not vim.uv.fs_stat(lazypath) then
  vim.system({
    'git',
    'clone',
    '--filter=blob:none',
    'https://github.com/folke/lazy.nvim.git',
    '--branch=stable', -- latest stable release
    lazypath,
  }):wait()
end
vim.opt.runtimepath:prepend(lazypath)

require('lazy').setup({
  'chrisgrieser/nvim-various-textobjs',
  lazy = false,
  opts = { useDefaultKeymaps = true },
})
```

The commit 2a0d655054bd396b722f99d84bc4f7e02aa8bfc0 appears to have broke this.

## Checklist
- [x] Used only camelCase variable names.
- [x] If functionality is added or modified, also made respective changes to the
  `README.md` (the `.txt` file is auto-generated and does not need to be modified).
