### PR TITLE
fix: inner pyTripleQuotes not working properly on multi-line f-strings

### DIFF
--- a/lua/various-textobjs/charwise-textobjs.lua
+++ b/lua/various-textobjs/charwise-textobjs.lua
@@ -434,11 +434,15 @@ function M.pyTripleQuotes(scope)
 	local text = u.getNodeText(strNode)
 	local isMultiline = text:find("[\r\n]")
 
-	-- select `string_content` node, which is the inner docstring
-	if scope == "inner" then strNode = strNode:child(1) end
-
 	---@cast strNode TSNode
 	local startRow, startCol, endRow, endCol = vim.treesitter.get_node_range(strNode)
+
+	if scope == "inner" then
+		local startNode = strNode:child(1) or strNode
+		local endNode = strNode:child(strNode:child_count() - 2) or strNode
+		startRow, startCol, _, _ = vim.treesitter.get_node_range(startNode)
+		_, _, endRow, endCol = vim.treesitter.get_node_range(endNode)
+	end
 
 	-- fix various off-by-ones
 	startRow = startRow + 1


### PR DESCRIPTION
Treesitter captures have probably changed since the original `pyTripleQuotes` function was written. There can now be multiple `string_content` nodes in triple-quoted f-strings which causes the current code to not highlight multi-line triple-quoted f-strings properly using the "inner" version of the operator.

Using the `iy` operator while the cursor in on `This` in the following python code reproduces the issue.

```python
a = 'a'

b = f"""
    This is {a} multiline triple-quoted f-string
"""
```

<img width="1415" alt="Screenshot 2024-07-25 at 2 29 35 PM" src="https://github.com/user-attachments/assets/83aac7fe-b2ec-4492-85d1-763cad3e6bae">

Changes tested on Neovim v0.9.4, v0.10.0 and v0.10.1


## Checklist
- [X] Used only camelCase variable names.
- [X] If functionality is added or modified, also made respective changes to the
  `README.md` (the `.txt` file is auto-generated and does not need to be modified).
