### PR TITLE
fix: inner `lineCharacterwise` including trailing whitespace

### DIFF
--- a/lua/various-textobjs/charwise-textobjs.lua
+++ b/lua/various-textobjs/charwise-textobjs.lua
@@ -227,7 +227,7 @@ end
 ---current line (but characterwise)
 ---@param scope "inner"|"outer" outer includes indentation and trailing spaces
 function M.lineCharacterwise(scope)
-	local pattern = "^(%s*).*(%s*)$"
+	local pattern = "^(%s*).-(%s*)$"
 	M.selectTextobj(pattern, scope, 0)
 end
 


### PR DESCRIPTION
To reproduce the issue, use the inner version of `lineCharacterwise` on this text: `       Lorem ipsum dolor sit amet       `; the selected text will be `Lorem ipsum dolor sit amet       `.

This change makes the the inner version of the operator work properly.