### PR TITLE
fix: `lineCharacterwise` hanging on NUL

### DIFF
--- a/lua/various-textobjs/charwise-textobjs.lua
+++ b/lua/various-textobjs/charwise-textobjs.lua
@@ -227,11 +227,11 @@ end
 ---current line (but characterwise)
 ---@param scope "inner"|"outer" outer includes indentation and trailing spaces
 function M.lineCharacterwise(scope)
-	-- FIX being on line break in visual mode, see #108
+	-- FIX being on NUL, see #108 and #109
 	-- (Not sure why this only happens for `lineCharacterwise` though…)
 	-- `col()` results in "true" char, as it factors in Tabs
-	local isOnLineBreak = #vim.api.nvim_get_current_line() < vim.fn.col(".")
-	if isOnLineBreak and vim.fn.mode():find("[Vv]") and scope == "outer" then u.normal("h") end
+	local isOnNUL = #vim.api.nvim_get_current_line() < vim.fn.col(".")
+	if isOnNUL then u.normal("g_") end
 
 	local pattern = "^(%s*).-(%s*)$"
 	M.selectTextobj(pattern, scope, 0)


### PR DESCRIPTION
This is related to #108
Upon further inspection I noticed that issue affected the inner variant and other modes too (assuming `virtualedit` is set to `all` or `onemore`) and that it wasn't line breaks causing it, but the cursor being on NUL (at least, according to `:ascii`).
These small changes should resolve the issue for the above-mentioned edge case.

While I was at it, I also tested if the other textobjs hanged on NUL, but it truly seems to only affect `lineCharacterwise` (although, I did notice some unrelated issues that I may submit later separately).

## Checklist
- [x] Used only camelCase variable names.