### PR TITLE
feat(linewise-textobjs): add count and iteration support

### DIFF
--- a/lua/various-textobjs/default-keymaps.lua
+++ b/lua/various-textobjs/default-keymaps.lua
@@ -76,7 +76,7 @@ function M.setup(disabledKeymaps)
 	end
 	-- stylua: ignore start
 	keymap( { "o", "x" }, "ii" , "<cmd>lua require('various-textobjs').indentation('inner', 'inner')<CR>", { desc = "inner-inner indentation textobj" })
-	keymap( { "o", "x" }, "ai" , "<cmd>lua require('various-textobjs').indentation('outer', 'inner')<CR>", { desc = "outer-inner indentation textobj" })
+	keymap( { "o", "x" }, "ai" , "<cmd>lua require('various-textobjs').indentation('outer', 'innerWithBlanks')<CR>", { desc = "outer-inner indentation textobj" })
 	keymap( { "o", "x" }, "iI" , "<cmd>lua require('various-textobjs').indentation('inner', 'inner')<CR>", { desc = "inner-inner indentation textobj" })
 	keymap( { "o", "x" }, "aI" , "<cmd>lua require('various-textobjs').indentation('outer', 'outer')<CR>", { desc = "outer-outer indentation textobj" })
 	-- stylua: ignore end

--- a/lua/various-textobjs/linewise-textobjs.lua
+++ b/lua/various-textobjs/linewise-textobjs.lua
@@ -10,6 +10,18 @@ local function isVisualLineMode()
 	return modeWithV ~= nil
 end
 
+---@return boolean
+local function isVisualBlockMode()
+	local modeWithCTRL_V = vim.fn.mode():find("")
+	return modeWithCTRL_V ~= nil
+end
+
+---@return boolean
+local function isVisualAnyMode()
+	local modeWithVvCTRL_V = vim.fn.mode():find("[vV]")
+	return modeWithVvCTRL_V ~= nil
+end
+
 ---sets the selection for the textobj (linewise)
 ---@param startline integer
 ---@param endline integer
@@ -20,6 +32,27 @@ local function setLinewiseSelection(startline, endline)
 	if not isVisualLineMode() then u.normal("V") end
 	u.normal("o")
 	vim.api.nvim_win_set_cursor(0, { endline, 0 })
+end
+
+-- Gets the (1,0)-indexed visual selection endpoints
+-- Unlike vim.fn.getpos("v") the endpoints are relative to the current cursor position
+---@return pos? opposite
+---@return pos? adjacent
+---@return pos? adjacent-opposite
+local function getSelectionEndpoints()
+	if not isVisualAnyMode() then return end
+	u.normal("o")
+	local b = vim.api.nvim_win_get_cursor(0)
+	if isVisualBlockMode() then
+		u.normal("O")
+		local c = vim.api.nvim_win_get_cursor(0)
+		u.normal("o")
+		local d = vim.api.nvim_win_get_cursor(0)
+		u.normal("O")
+		return b, c, d
+	end
+	u.normal("o")
+	return b
 end
 
 ---@param lineNr number
@@ -39,28 +72,42 @@ function M.closedFold(scope)
 	local startLnum = vim.api.nvim_win_get_cursor(0)[1]
 	local lastLine = vim.api.nvim_buf_line_count(0)
 	local startedOnFold = vim.fn.foldclosed(startLnum) > 0
+	local count = vim.v.count1
+	local selectionTailLnum = (getSelectionEndpoints() or {})[1]
+	local replaceSelection = selectionTailLnum or startedOnFold and startLnum == selectionTailLnum
 	local foldStart, foldEnd
 
 	if startedOnFold then
 		foldStart = vim.fn.foldclosed(startLnum)
 		foldEnd = vim.fn.foldclosedend(startLnum)
-	else
+		count = count - 1
+	end
+	if count > 0 then
 		foldStart = startLnum
+		local lastClosedFold
 		repeat
 			if foldStart >= lastLine or foldStart > (config.lookForwardBig + startLnum) then
 				u.notFoundMsg(config.lookForwardBig)
 				return
 			end
 			foldStart = foldStart + 1
-			local reachedClosedFold = vim.fn.foldclosed(foldStart) > 0
-		until reachedClosedFold
+			local closedFold = vim.fn.foldclosed(foldStart)
+			local reachedClosedFold = closedFold > 0
+			if reachedClosedFold and closedFold ~= lastClosedFold then
+				count = count - 1
+				lastClosedFold = closedFold
+			end
+		until count == 0
 		foldEnd = vim.fn.foldclosedend(foldStart)
 	end
+
+	local selectionStart = replaceSelection and foldStart
+		or (isVisualAnyMode() and selectionTailLnum or foldStart) -- + (foldEnd - foldStart)
 	if scope == "outer" and (foldEnd + 1 <= lastLine) then foldEnd = foldEnd + 1 end
 
 	-- fold has to be opened for so line can be correctly selected
 	vim.cmd(("%d,%d foldopen"):format(foldStart, foldEnd))
-	setLinewiseSelection(foldStart, foldEnd)
+	setLinewiseSelection(selectionStart, foldEnd)
 
 	-- if yanking, close the fold afterwards again.
 	-- (For the other operators, opening the fold does not matter (d) or is desirable (gu).)
@@ -81,13 +128,20 @@ end
 
 ---rest of paragraph (linewise)
 function M.restOfParagraph()
+	local count = vim.v.count1
 	if not isVisualLineMode() then u.normal("V") end
-	u.normal("}")
+	u.normal(count .. "}")
 
 	-- one up, except on last line
 	local curLnum = vim.api.nvim_win_get_cursor(0)[1]
 	local lastLine = vim.api.nvim_buf_line_count(0)
 	if curLnum ~= lastLine then u.normal("k") end
+	-- curLnum = vim.api.nvim_win_get_cursor(0)[1]
+	-- if curLnum == initLnum and startsVisualLine then
+	-- 	u.normal("2}")
+	-- 	curLnum = vim.api.nvim_win_get_cursor(0)[1]
+	-- 	if curLnum ~= lastLine then u.normal("k") end
+	-- end
 end
 
 ---Md Fenced Code Block Textobj
@@ -95,6 +149,7 @@ end
 function M.mdFencedCodeBlock(scope)
 	local cursorLnum = vim.api.nvim_win_get_cursor(0)[1]
 	local codeBlockPattern = "^```%w*$"
+	local count = vim.v.count1
 
 	-- scan buffer for all code blocks, add beginnings & endings to a table each
 	local cbBegin = {}
@@ -115,6 +170,9 @@ function M.mdFencedCodeBlock(scope)
 	if #cbBegin > #cbEnd then table.remove(cbBegin) end -- incomplete codeblock
 
 	-- determine cursor location in a codeblock
+	local selectionTailLnum = (getSelectionEndpoints() or {})[1]
+	local replaceSelection = selectionTailLnum and cursorLnum == selectionTailLnum
+	local instance = count
 	local j = 0
 	repeat
 		j = j + 1
@@ -126,13 +184,19 @@ function M.mdFencedCodeBlock(scope)
 		-- seek forward for a codeblock
 		local cursorInFront = (cbBegin[j] > cursorLnum)
 			and (cbBegin[j] <= cursorLnum + config.lookForwardBig)
-	until cursorInBetween or cursorInFront
+		if cursorInBetween or cursorInFront then instance = instance - 1 end
+	until (cursorInBetween or cursorInFront) and instance <= 0
 
 	local start = cbBegin[j]
 	local ending = cbEnd[j]
+	if replaceSelection then start = cbBegin[j - count + 1] end
 	if scope == "inner" then
 		start = start + 1
 		ending = ending - 1
+	end
+	if not replaceSelection then
+		if cursorLnum == ending then ending = cbBegin[j + 1] - 1 end
+		start = selectionTailLnum
 	end
 
 	setLinewiseSelection(start, ending)
@@ -154,94 +218,149 @@ end
 
 --------------------------------------------------------------------------------
 
+-- the og indent-object is quite inconsistent
+-- ai will stop right before the upper boundary depending on the indentation level (try 2 vs 4)
+-- the selected indentation level is dictated by the cendpoint loc (e.g. same indent broken up
+-- by a single line of a lower one)
+-- thus, it replaces only if cendpoint is in a different indentation
+-- if the min (minimum area of the object) is selected extends otherwise it replaces (blockobj
+-- should always replace)
+-- the min isn't of the closest obj near the cursor but the parentmost indentation under a cendpoint
+-- ai/aI iter (once selected the min) will seek upwards by one whitespace or (^%S$)+(^%s$)* then use the seekd line as new
+-- indentlevel instead of selecting parent indent (and includes extra uppper line)
+-- ii iter (once selected the min) will seek upwards by one whitespace or (^%S$)+ then use the seekd line as new
+-- indentlevel instead of selecting parent indent
+
 ---indentation textobj
 ---@param startBorder "inner"|"outer"
----@param endBorder "inner"|"outer"
+---@param endBorder "inner"|"innerWithBlanks"|"outer"
 ---@param blankLines? "withBlanks"|"noBlanks"
 function M.indentation(startBorder, endBorder, blankLines)
 	if not blankLines then blankLines = "withBlanks" end
 
 	local curLnum = vim.api.nvim_win_get_cursor(0)[1]
+	local firstLine = 1
 	local lastLine = vim.api.nvim_buf_line_count(0)
-	while isBlankLine(curLnum) do -- when on blank line, use next line
-		if lastLine == curLnum then
-			u.notify("No indented line found.", "notfound")
-			return
-		end
-		curLnum = curLnum + 1
-	end
-
-	local indentOfStart = vim.fn.indent(curLnum)
-	if indentOfStart == 0 then
-		u.notify("Current line is not indented.", "notfound")
-		return false -- return value needed for greedyOuterIndentation textobj
-	end
-
-	local prevLnum = curLnum - 1
-	local nextLnum = curLnum + 1
-
-	while
-		prevLnum > 0
-		and (
-			(blankLines == "withBlanks" and isBlankLine(prevLnum))
-			or vim.fn.indent(prevLnum) >= indentOfStart
-		)
-	do
+	local count = vim.v.count1
+	local selectionTailLnum = (getSelectionEndpoints() or {})[1]
+	local prevLnum = curLnum
+	local nextLnum = curLnum
+	while isBlankLine(prevLnum) and prevLnum ~= firstLine do
 		prevLnum = prevLnum - 1
 	end
-	while
-		nextLnum <= lastLine
-		and (
-			(blankLines == "withBlanks" and isBlankLine(nextLnum))
-			or vim.fn.indent(nextLnum) >= indentOfStart
-		)
-	do
+	while isBlankLine(nextLnum) and nextLnum ~= lastLine do
 		nextLnum = nextLnum + 1
 	end
 
-	-- differentiate ai and ii
-	if startBorder == "inner" then prevLnum = prevLnum + 1 end
-	if endBorder == "inner" then nextLnum = nextLnum - 1 end
+	local userBorderUpper
+	local userBorderLower
+	local iterToParentInstance
+	repeat
+		local indentOfStart = math.max(vim.fn.indent(nextLnum), vim.fn.indent(prevLnum))
+		if indentOfStart == 0 then
+			u.notify("Target line is not indented.", "notfound")
+			return "notIndented" -- return value needed for greedyOuterIndentation textobj
+		end
+		while
+			prevLnum > firstLine
+			and (
+				(blankLines == "withBlanks" and isBlankLine(prevLnum))
+				or vim.fn.indent(prevLnum) >= indentOfStart
+			)
+		do
+			prevLnum = prevLnum - 1
+		end
+		while
+			nextLnum < lastLine
+			and (
+				(blankLines == "withBlanks" and isBlankLine(nextLnum))
+				or vim.fn.indent(nextLnum) >= indentOfStart
+			)
+		do
+			nextLnum = nextLnum + 1
+		end
 
-	while isBlankLine(nextLnum) do
-		nextLnum = nextLnum - 1
+		local noUpperBound = prevLnum == firstLine
+			and (
+				(blankLines == "withBlanks" and isBlankLine(firstLine))
+				or vim.fn.indent(firstLine) >= indentOfStart
+			)
+		local noLowerBound = nextLnum == lastLine
+			and (
+				(blankLines == "withBlanks" and isBlankLine(lastLine))
+				or vim.fn.indent(lastLine) >= indentOfStart
+			)
+
+		-- use separate variables to keep old Lnum values for future count/iter loops
+		userBorderUpper = prevLnum
+		userBorderLower = nextLnum
+
+		-- differentiate ai and ii
+		if
+			(startBorder == "inner" or startBorder == "innerWithBlanks")
+			and (userBorderUpper < lastLine and userBorderUpper < nextLnum)
+			and not noUpperBound
+		then
+			userBorderUpper = userBorderUpper + 1
+		end
+		if
+			(endBorder == "inner" or endBorder == "innerWithBlanks")
+			and (userBorderLower > firstLine and userBorderLower > prevLnum)
+			and not noLowerBound
+		then
+			userBorderLower = userBorderLower - 1
+		end
+
+		while startBorder == "inner" and isBlankLine(userBorderUpper) do
+			userBorderUpper = userBorderUpper + 1
+		end
+		while endBorder == "inner" and isBlankLine(userBorderLower) do
+			userBorderLower = userBorderLower - 1
+		end
+		count = count - 1
+
+		-- ii has iteration limits, since it can lead to a crossBoundary state
+		iterToParentInstance = (
+			(userBorderUpper == selectionTailLnum and userBorderLower == curLnum)
+			or (userBorderLower == selectionTailLnum and userBorderUpper == curLnum)
+		) and isVisualLineMode()
+	until not (iterToParentInstance or count > 0)
+
+	-- makes nullop when endpoint is beyond object boundaries
+	local crossBoundary = selectionTailLnum
+		and (
+			(prevLnum <= curLnum and curLnum < nextLnum and nextLnum < selectionTailLnum)
+			or (selectionTailLnum < prevLnum and prevLnum < curLnum and curLnum <= nextLnum)
+		)
+	if crossBoundary then
+		u.notify("Existing selection crosses object boundary.", "notfound")
+		return "crossBoundary"
 	end
 
-	setLinewiseSelection(prevLnum, nextLnum)
+	-- it should also disable iter for counts above 1 -- does this by itself?
+	-- because it's a blockobj
+	-- it never extend selection but always replaces it
+	-- it isn't directional since count/iter should go to the parent match
+	setLinewiseSelection(userBorderUpper, userBorderLower)
 end
 
+--TODO: use new indentation() logic
 ---from cursor position down all lines with same or higher indentation;
 ---essentially `ii` downwards
 function M.restOfIndentation()
 	local startLnum = vim.api.nvim_win_get_cursor(0)[1]
-	local lastLine = vim.api.nvim_buf_line_count(0)
-	local curLnum = startLnum
-	while isBlankLine(curLnum) do -- when on blank line, use next line
-		if lastLine == curLnum then return end
-		curLnum = curLnum + 1
-	end
-
-	local indentOfStart = vim.fn.indent(curLnum)
-	if indentOfStart == 0 then
-		u.notify("Current line is not indented.", "notfound")
-		return
-	end
-
-	local nextLnum = curLnum + 1
-
-	while isBlankLine(nextLnum) or vim.fn.indent(nextLnum) >= indentOfStart do
-		if nextLnum > lastLine then break end
-		nextLnum = nextLnum + 1
-	end
-
-	setLinewiseSelection(startLnum, nextLnum - 1)
+	M.indentation("inner", "inner")
+	local curLnum = vim.api.nvim_win_get_cursor(0)[1]
+	setLinewiseSelection(startLnum, curLnum)
 end
 
+-- ISSUE: this function uses `{` and `}` to skip to "blank lines" but according to isBlankLine()
+-- "blank lines" includes whitespace-only lines, which `{` and `}` skips over
 ---outer indentation, expanded until the next blank lines in both directions
 ---@param scope "inner"|"outer" outer adds a blank, like ip/ap textobjs
 function M.greedyOuterIndentation(scope)
 	-- select outer indentation
-	local invalid = M.indentation("outer", "outer") == false
+	local invalid = M.indentation("outer", "outer")
 	if invalid then return end
 	u.normal("o{j") -- to next blank line above
 	u.normal("o}") -- to next blank line down
@@ -268,20 +387,38 @@ function M.notebookCell(scope)
 
 	local curLnum = vim.api.nvim_win_get_cursor(0)[1]
 	local lastLine = vim.api.nvim_buf_line_count(0)
-	local prevLnum = curLnum
+	local prevLnum
 	local nextLnum = isCellBorder(curLnum) and curLnum + 1 or curLnum
+	local count = vim.v.count1
 
-	while prevLnum > 0 and not isCellBorder(prevLnum) do
+	local selectionTailLnum = (getSelectionEndpoints() or {})[1]
+	local replaceSelection = selectionTailLnum and curLnum == selectionTailLnum
+	local firstLoop = true
+
+	repeat
+		while nextLnum < lastLine and not isCellBorder(nextLnum) do
+			nextLnum = nextLnum + 1
+		end
+		if firstLoop then
+			firstLoop = false
+			local nextInstance = nextLnum - 1 == curLnum and not replaceSelection
+			if nextInstance then count = count + 1 end
+		end
+		count = count - 1
+		if count > 0 and nextLnum < lastLine and isCellBorder(nextLnum) then
+			nextLnum = nextLnum + 1
+		end
+	until count <= 0
+	prevLnum = nextLnum - 1
+	while prevLnum > 1 and not isCellBorder(prevLnum) do
 		prevLnum = prevLnum - 1
-	end
-	while nextLnum <= lastLine and not isCellBorder(nextLnum) do
-		nextLnum = nextLnum + 1
 	end
 
 	-- outer includes bottom cell border
-	if scope == "outer" and nextLnum < lastLine then nextLnum = nextLnum + 1 end
+	if scope == "inner" and nextLnum < lastLine then nextLnum = nextLnum - 1 end
+	if not replaceSelection then prevLnum = selectionTailLnum end
 
-	setLinewiseSelection(prevLnum + 1, nextLnum - 1)
+	setLinewiseSelection(prevLnum, nextLnum)
 end
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
It should be noted this does not yet add support for the direction in which iteration goes, thus, right now it always goes down-wards for non-block textobjs.
I'll normalize variable names and update documentation later on.
I've already been running these changes daily for more than a month, slowly ironing out any issues I found, but I figured it would be important to set up a draft pr for the purpose of discussion, especially around the indentation textobjs.

## Checklist
- [ ] Used only camelCase variable names.
- [ ] If functionality is added or modified, also made respective changes to the
  `README.md` (the `.txt` file is auto-generated and does not need to be modified).
