### PR TITLE
feat(html attributes and svelte): Update default-keymaps.lua

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Bundle of more than 30 new text objects for Neovim.
 | `mdEmphasis`                   | Markdown text enclosed by `*`, `**`, `_`, `__`, `~~`, or `==`                                      | inner is only the emphasis content              | small           |      `ie`/`ae`      | `markdown`                          |
 | `mdFencedCodeBlock`            | Markdown fenced code (enclosed by three backticks)                                                 | outer includes the enclosing backticks          | big             |      `iC`/`aC`      | `markdown`                          |
 | `cssSelector`                  | class in CSS such as `.my-class`                                                                   | outer includes trailing comma and space         | small           |      `ic`/`ac`      | `css`, `scss`                       |
-| `htmlAttribute`                | attribute in HTML/XML like `href="foobar.com"`                                                     | inner is only the value inside the quotes       | small           |      `ix`/`ax`      | `html`, `xml`, `css`, `scss`, `vue` |
+| `htmlAttribute`                | attribute in HTML/XML like `href="foobar.com"`                                                     | inner is only the value inside the quotes       | small           |      `ix`/`ax`      | `html`, `xml`, `css`, `scss`, `vue`, `svelte` |
 | `shellPipe`                    | segment until/after a pipe character (`\|`)                                                        | outer includes the pipe                         | small           |      `iP`/`aP`      | `bash`, `zsh`, `fish`, `sh`         |
 
 <!-- LTeX: enabled=true -->

--- a/lua/various-textobjs/config/default-keymaps.lua
+++ b/lua/various-textobjs/config/default-keymaps.lua
@@ -39,7 +39,7 @@ local ftMaps = {
 	{ map = { mdFencedCodeBlock = "C" }, fts = { "markdown" } },
 	{ map = { cssSelector = "c" }, fts = { "css", "scss" } },
 	{ map = { shellPipe = "P" }, fts = { "sh", "bash", "zsh", "fish" } },
-	{ map = { htmlAttribute = "x" }, fts = { "html", "css", "scss", "xml", "vue" } },
+	{ map = { htmlAttribute = "x" }, fts = { "html", "css", "scss", "xml", "vue", "svelte" } },
 }
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
Add svelte support

## What problem does this PR solve?

Adds missing Svelte support.

## How does the PR solve it?

Add `svelte` to list of filetypes.

## Checklist
- [x] Used only `camelCase` variable names.
- [x] If functionality is added or modified, also made respective changes to the
  `README.md` (the `.txt` file is auto-generated and does not need to be
  modified).
